### PR TITLE
fix: remove custom launcher config

### DIFF
--- a/karma.ci.conf.js
+++ b/karma.ci.conf.js
@@ -14,14 +14,16 @@ module.exports = (config) => {
     output[`${browser}Latest`] = {
       base: 'SauceLabs',
       browserName: browser.toLowerCase(),
-      version: browser === 'Safari' ? 'latest-1' : 'latest'
+      browserVersion: 'latest',
+      platformName: browser === 'Safari' ? 'Mac 10.15' : 'Windows 10'
     };
 
     if (browser !== 'Internet Explorer') {
       output[`${browser}Prior`] = {
         base: 'SauceLabs',
         browserName: browser.toLowerCase(),
-        version: browser === 'Safari' ? 'latest-2' : 'latest-1'
+        browserVersion: 'latest-1',
+        platformName: browser === 'Safari' ? 'Mac 10.15' : 'Windows 10'
       };
     }
 


### PR DESCRIPTION
The customLaunchers list was previously added to overcome a 500 error when testing against Safari 12.  The underlying cause was not known at the time.  Now, we are receiving an error because SauceLabs is trying to run the Safari customLaunchers entry on Windows.  So far I can't find any documentation indicating that there is a new requirement that needs to be accounted for in customLaunchers configurations (such as the need to specify platformName).  Unfortunately, this leads us to some trial and error testing.  As a result, I want to try to eliminate the customLaunchers configuration completely before I start adding constraints to the customLaunchers configuration.